### PR TITLE
[FEATURE] Add random sorting to expert mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /Resources/Public/bower_components
 /node_modules
+.idea

--- a/Configuration/FlexForms/slick-responsive.xml
+++ b/Configuration/FlexForms/slick-responsive.xml
@@ -110,7 +110,8 @@
                     </easing>
                     <edgeFriction type="array">
                         <TCEforms type="array">
-                            <label>LLL:EXT:slickcarousel/Resources/Private/Language/be_locallang.xlf:edgeFriction</label>
+                            <label>LLL:EXT:slickcarousel/Resources/Private/Language/be_locallang.xlf:edgeFriction
+                            </label>
                             <config type="array">
                                 <type>input</type>
                                 <size>1</size>
@@ -156,14 +157,43 @@
                             </config>
                         </TCEforms>
                     </initialSlide>
+                    <randomSlide type="array">
+                        <TCEforms type="array">
+                            <label>LLL:EXT:slickcarousel/Resources/Private/Language/be_locallang.xlf:randomSlide
+                            </label>
+                            <config type="array">
+                                <type>radio</type>
+                                <items type="array">
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">LLL:EXT:slickcarousel/Resources/Private/Language/be_locallang.xlf:randomSlide.none</numIndex>
+                                        <numIndex index="1">off</numIndex>
+                                    </numIndex>
+                                    <numIndex index="1" type="array">
+                                        <numIndex index="0">LLL:EXT:slickcarousel/Resources/Private/Language/be_locallang.xlf:randomSlide.js</numIndex>
+                                        <numIndex index="1">js</numIndex>
+                                    </numIndex>
+                                    <numIndex index="3" type="array">
+                                        <numIndex index="0">LLL:EXT:slickcarousel/Resources/Private/Language/be_locallang.xlf:randomSlide.vhs</numIndex>
+                                        <numIndex index="1">vhs</numIndex>
+                                    </numIndex>
+                                </items>
+                            </config>
+                        </TCEforms>
+                    </randomSlide>
                     <lazyLoad type="array">
                         <TCEforms type="array">
                             <label>LLL:EXT:slickcarousel/Resources/Private/Language/be_locallang.xlf:lazyLoad</label>
                             <config type="array">
                                 <type>select</type>
                                 <items type="array">
-                                    <numIndex index="0" type="array"><numIndex index="0">ondemand</numIndex><numIndex index="1">ondemand</numIndex></numIndex>
-                                    <numIndex index="1" type="array"><numIndex index="0">progressive</numIndex><numIndex index="1">progressive</numIndex></numIndex>
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">ondemand</numIndex>
+                                        <numIndex index="1">ondemand</numIndex>
+                                    </numIndex>
+                                    <numIndex index="1" type="array">
+                                        <numIndex index="0">progressive</numIndex>
+                                        <numIndex index="1">progressive</numIndex>
+                                    </numIndex>
                                 </items>
                                 <default>ondemand</default>
                             </config>
@@ -195,9 +225,18 @@
                             <config type="array">
                                 <type>select</type>
                                 <items type="array">
-                                    <numIndex index="0" type="array"><numIndex index="0">window</numIndex><numIndex index="1">window</numIndex></numIndex>
-                                    <numIndex index="1" type="array"><numIndex index="0">slider</numIndex><numIndex index="1">slider</numIndex></numIndex>
-                                    <numIndex index="2" type="array"><numIndex index="0">min</numIndex><numIndex index="1">min</numIndex></numIndex>
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">window</numIndex>
+                                        <numIndex index="1">window</numIndex>
+                                    </numIndex>
+                                    <numIndex index="1" type="array">
+                                        <numIndex index="0">slider</numIndex>
+                                        <numIndex index="1">slider</numIndex>
+                                    </numIndex>
+                                    <numIndex index="2" type="array">
+                                        <numIndex index="0">min</numIndex>
+                                        <numIndex index="1">min</numIndex>
+                                    </numIndex>
                                 </items>
                                 <default>window</default>
                             </config>

--- a/Resources/Private/Language/be_locallang.xlf
+++ b/Resources/Private/Language/be_locallang.xlf
@@ -84,6 +84,18 @@
 			<trans-unit id="initialSlide" xml:space="preserve">
 				<source>initialSlide: Slide to start on</source>
 			</trans-unit>
+			<trans-unit id="randomSlide" xml:space="preserve">
+				<source>randomSlide: Select random mode</source>
+			</trans-unit>
+			<trans-unit id="randomSlide.none" xml:space="preserve">
+				<source>Off</source>
+			</trans-unit>
+			<trans-unit id="randomSlide.js" xml:space="preserve">
+				<source>Random starting slide (pseudo random)</source>
+			</trans-unit>
+			<trans-unit id="randomSlide.vhs" xml:space="preserve">
+				<source>Randomize selected images with vhs (slower)</source>
+			</trans-unit>
 			<trans-unit id="lazyLoad" xml:space="preserve">
 				<source>lazyLoad: Accepts 'ondemand' or 'progressive' for lazy load technique</source>
 			</trans-unit>

--- a/Resources/Private/Partials/AssetAll.html
+++ b/Resources/Private/Partials/AssetAll.html
@@ -7,6 +7,11 @@
 	<f:section name="JS-Responsive">
 		<v:asset.script fluid="true" rewrite="true" name="slick-id{data.uid}">
 			$(document).ready(function () {
+				<f:if condition="{data.pi_flexform.randomSlide} == 'js'">
+					var total = $('#slick-id{data.uid} img').length,
+					rand = Math.floor( Math.random() * total );
+				</f:if>
+
 				$('#slick-id{data.uid}').slick({
 					accessibility: <f:format.raw>{f:if(then: 'true',  else: 'false',  condition: data.pi_flexform.accessibility)}</f:format.raw>,
 					autoplay: <f:format.raw>{f:if(then: 'true',  else: 'false',  condition: data.pi_flexform.autoplay)}</f:format.raw>,
@@ -22,7 +27,14 @@
 					fade: <f:format.raw>{f:if(then: 'true',  else: 'false',  condition: data.pi_flexform.fade)}</f:format.raw>,
 					mobileFirst: <f:format.raw>{f:if(then: 'true',  else: 'false',  condition: data.pi_flexform.mobileFirst)}</f:format.raw>,
 					infinite: <f:format.raw>{f:if(then: 'true',  else: 'false',  condition: data.pi_flexform.infinite)}</f:format.raw>,
-					initialSlide: <f:format.raw>{data.pi_flexform.initialSlide}</f:format.raw>,
+					<f:if condition="{data.pi_flexform.randomSlide} == 'js'">
+						<f:then>
+							initialSlide: rand,
+						</f:then>
+						<f:else>
+							initialSlide: <f:format.raw>{data.pi_flexform.initialSlide}</f:format.raw>,
+						</f:else>
+					</f:if>
 					lazyLoad: '<f:format.raw>{data.pi_flexform.lazyLoad}</f:format.raw>',
 					pauseOnHover: <f:format.raw>{f:if(then: 'true',  else: 'false',  condition: data.pi_flexform.pauseOnHover)}</f:format.raw>,
 					pauseOnDotsHover: <f:format.raw>{f:if(then: 'true',  else: 'false',  condition: data.pi_flexform.pauseOnDotsHover)}</f:format.raw>,

--- a/Resources/Private/Templates/Slickcarousel.html
+++ b/Resources/Private/Templates/Slickcarousel.html
@@ -1,4 +1,5 @@
 <div xmlns="http://www.w3.org/1999/xhtml" lang="en"
+	 xmlns:v="http://typo3.org/ns/FluidTYPO3/Vhs/ViewHelpers"
 	 xmlns:f="http://xsd.helhum.io/ns/typo3/cms-fluid/master/ViewHelpers"
 	 data-namespace-typo3-fluid="true">
 
@@ -6,6 +7,10 @@
 
 	<f:section name="Main">
 		<div class="slick-slider slick-default" id="slick-id{data.uid}">
+			<f:if condition="{data.pi_flexform.randomSlide} == 'vhs'">
+				<v:iterator.sort subject="{slickimages}" as="slickimages" order="RAND" />
+			</f:if>
+
 			<f:for each="{slickimages}" as="file" iteration="i">
 				<div class="slick-item">
 					<figure>

--- a/Resources/Private/Templates/Slickcarouselbasic.html
+++ b/Resources/Private/Templates/Slickcarouselbasic.html
@@ -1,4 +1,5 @@
 <div xmlns="http://www.w3.org/1999/xhtml" lang="en"
+	 xmlns:v="http://typo3.org/ns/FluidTYPO3/Vhs/ViewHelpers"
 	 xmlns:f="http://xsd.helhum.io/ns/typo3/cms-fluid/master/ViewHelpers"
 	 data-namespace-typo3-fluid="true">
 
@@ -7,6 +8,10 @@
 	<f:section name="Main">
 
 		<div class="slick-slider slick-default" id="slick-id{data.uid}">
+			<f:if condition="{data.pi_flexform.randomSlide} == 'vhs'">
+				<v:iterator.sort subject="{slickimages}" as="slickimages" order="RAND" />
+			</f:if>
+
 			<f:for each="{slickimages}" as="file" iteration="i">
 				<div class="slick-item">
 					<figure>

--- a/Resources/Private/Templates/Slickcarouselsync.html
+++ b/Resources/Private/Templates/Slickcarouselsync.html
@@ -1,10 +1,14 @@
 <div xmlns="http://www.w3.org/1999/xhtml" lang="en"
+	 xmlns:v="http://typo3.org/ns/FluidTYPO3/Vhs/ViewHelpers"
 	 xmlns:f="http://xsd.helhum.io/ns/typo3/cms-fluid/master/ViewHelpers"
 	 data-namespace-typo3-fluid="true">
 
 	<f:layout name="Default" />
 
 	<f:section name="Main">
+		<f:if condition="{data.pi_flexform.randomSlide} == 'vhs'">
+			<v:iterator.sort subject="{slickimages}" as="slickimages" order="RAND" />
+		</f:if>
 
 		<div class="slick-slider slick-default" id="slick-id{data.uid}-main">
 			<f:for each="{slickimages}" as="file" iteration="i">

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "version": "0.0.5",
   "require": {
     "typo3/cms": ">=7.6.0,<8.0",
-    "fluidtypo3/vhs": "^2.3.3"
+    "fluidtypo3/vhs": "*"
   },
   "authors": [
     {


### PR DESCRIPTION
Added a checkbox to enable simple random slides.

Actually this pull only selects a random starting point for the slider. A more random option would be to sort the fal images randomly on every request. But this would also slow down the site, because the caching has to be turned off.

This could be done by using ```v:render.uncached```.

I don’t know, but should ```v:iterate.random``` work for this?